### PR TITLE
Fix new loom versions

### DIFF
--- a/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessPlugin.kt
+++ b/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessPlugin.kt
@@ -319,7 +319,7 @@ private val Project.notchMappings: Mappings?
 
 private val Project.tinyMappings: File?
     get() {
-        val extension = extensions.findByName("minecraft") ?: return null
+        val extension = extensions.findByName("loom") ?: extensions.findByName("minecraft") ?: return null
         if (!extension.javaClass.name.contains("LoomGradleExtension")) return null
         val mappingsProvider = extension.withGroovyBuilder { getProperty("mappingsProvider") }
         mappingsProvider.maybeGetGroovyProperty("MAPPINGS_TINY")?.let { return it as File } // loom 0.2.5


### PR DESCRIPTION
Newer loom versions replaced the `minecraft` task with `loom`, thus the preprocessor fails to find intermediary and notch mappings. This PR accommodates for that by checking for the `loom` before checking for the `minecraft` one. The precedence of the `loom` task is important because the `minecraft` task still exists (said to be gone in loom 0.11) but fails on the class name check.