### PR TITLE
Add file/line information on errors from invalid expressions

### DIFF
--- a/src/test/kotlin/com/replaymod/gradle/preprocess/PreprocessorTests.kt
+++ b/src/test/kotlin/com/replaymod/gradle/preprocess/PreprocessorTests.kt
@@ -119,6 +119,14 @@ class PreprocessorTests : FunSpec({
                 shouldThrow<CommentPreprocessor.ParserException> { "//#if t".convert() }
                 shouldThrow<CommentPreprocessor.ParserException> { "//#if t\n//#if t\n//#endif".convert() }
             }
+            test("throws on missing space") {
+                shouldThrow<CommentPreprocessor.ParserException> { "//#ift\n//#endif".convert() }
+                shouldThrow<CommentPreprocessor.ParserException> { "//#if f\n//#elseift\n//#endif".convert() }
+            }
+            test("throws on empty if condition") {
+                shouldThrow<CommentPreprocessor.ParserException> { "//#if\n//#endif".convert() }
+                shouldThrow<CommentPreprocessor.ParserException> { "//#if f\n//#elseif\n//#endif".convert() }
+            }
             test("if t .. endif") {
                 """
                     //#if t


### PR DESCRIPTION
I had a situation in my repo where I accidentally put `//#elseif`, and the error message I got was `Invalid Expression:`, which isn't all that helpful. Now it should print the filename and line number, as it does with all of the other error conditions.

This also fixes a bug where the space could be omitted after `//#elseif` (i.e. `//#elseift` was valid) since I forgot to commit the elseif keywords with a space after them. 