### PR TITLE
fix classpath with kotlin 1.7

### DIFF
--- a/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessPlugin.kt
+++ b/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessPlugin.kt
@@ -354,7 +354,7 @@ private val Task.classpath: FileCollection?
         // assume kotlin 1.7+
         try {
             val classpathMethod = this.javaClass.getMethod("getLibraries")
-            classpathMethod.invoke(this) as? FileCollection
+            classpathMethod.invoke(this) as FileCollection?
         } catch (ex: Exception) {
             throw RuntimeException(ex)
         }


### PR DESCRIPTION
starting from Kotlin 1.7, `KotlinCompile` no longer inherits `AbstractCompile`. this pr works around this