### PR TITLE
Compat with Fabric Loom 1.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessPlugin.kt
+++ b/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessPlugin.kt
@@ -331,7 +331,11 @@ private val Project.mappingsProvider: Any?
     get() {
         val extension = extensions.findByName("loom") ?: extensions.findByName("minecraft") ?: return null
         if (!extension.javaClass.name.contains("LoomGradleExtension")) return null
-        return extension.withGroovyBuilder { getProperty("mappingsProvider") }
+        // Fabric Loom has changed its property names since 1.1
+        listOf("mappingConfiguration", "mappingsProvider").forEach { pro ->
+            extension.maybeGetGroovyProperty(pro)?.also { return it }
+        }
+        return null
     }
 
 private val Project.tinyMappings: File?


### PR DESCRIPTION
Fabric Loom 1.1 changed the extension property name. This causes the Preprocessor to fail to obtain the mappings configuration.
Details of the changes to Fabric Loom:
https://github.com/FabricMC/fabric-loom/commit/06074ae73c7c3c2967cdafbd1af542696d6ffe61#diff-bd996514664baf59a914cd4877399a2b93afee58745a881e3a68144626e0c491L75-R77