### PR TITLE
Fix setCoreVersion not working

### DIFF
--- a/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessPlugin.kt
+++ b/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessPlugin.kt
@@ -214,7 +214,7 @@ class PreprocessPlugin : Plugin<Project> {
 
                 from(project.file("src"))
                 from(project.layout.buildDirectory.dir("preprocessed"))
-                into(project.layout.projectDirectory.dir("src"))
+                into(project.parent!!.layout.projectDirectory.dir("src"))
 
                 project.the<SourceSetContainer>().all {
                     val cName = if (name == "main") "" else name.uppercaseFirstChar()


### PR DESCRIPTION
Currently the `version:setCoreVersion` gradle task does not work at all. This issue was introduced in https://github.com/ReplayMod/preprocessor/commit/bd94585a5ce658481bf0d05d373feea70adbcf10#diff-685e143269c0f7dc55e6a7df5984abce2494c04cf47d9fa6fe4f455a1fafea43L197

And here's a quick fix for it